### PR TITLE
[TASK] Split sub-processes out using Supervisor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,27 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of Codius: https://github.com/codius
+    Copyright (c) 2014 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
 var path = require('path');
 
-module.exports.Server      = require(path.join(__dirname, 'server'))
-module.exports.Application = require(path.join(__dirname, 'application'))
+module.exports.Server      = require(path.join(__dirname, 'server'));
+module.exports.Application = require(path.join(__dirname, 'application'));
+module.exports.Manager     = require(path.join(__dirname, 'manager')).Manager;
+module.exports.features    = require(path.join(__dirname, 'features'));
+module.exports.config      = require(path.join(__dirname, 'config'));
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bitcoinjs-lib": "^1.4.3",
     "bluebird": "^2.3.6",
     "bookshelf": "^0.7.7",
+    "bridges-application": "^0.2.1",
     "chalk": "^0.5.1",
     "codius-engine": "https://github.com/codius/codius-engine/tarball/master",
     "commander": "^2.6.0",

--- a/processes/amortization.js
+++ b/processes/amortization.js
@@ -17,13 +17,14 @@
 */
 //==============================================================================
 
-var BridgesApplication = require('bridges-application');
-var codius             = require(__dirname+'/lib');
+module.exports = function(codius) {
 
-new BridgesApplication({
-  directory: __dirname,
-  processes: {
-    inject: [codius]
+  if (codius.features.isEnabled('BILLING_GENERIC')) {
+
+    var manager = new codius.Manager({
+      pollInterval: 100,
+      millisecondsPerComputeUnit: codius.config.get('millisecondsPerComputeUnit') || 100
+    });
   }
-}).supervisor.start();
+}
 

--- a/processes/bitcoin_billing.js
+++ b/processes/bitcoin_billing.js
@@ -17,13 +17,14 @@
 */
 //==============================================================================
 
-var BridgesApplication = require('bridges-application');
-var codius             = require(__dirname+'/lib');
+module.exports = function(codius) {
 
-new BridgesApplication({
-  directory: __dirname,
-  processes: {
-    inject: [codius]
+  if (codius.features.isEnabled('BITCOIN_BILLING')) {
+    if (!codius.config.get('bitcoin_bip32_extended_public_key')) {
+      var message =  'Must set bitcoin_bip32_extended_public_key config option.'; 
+          message += 'To generate a BIP32 HD Wallet you can use https://bip32jp.github.io/english/';
+      throw new Error(message);
+    }
   }
-}).supervisor.start();
+}
 

--- a/processes/ripple_billing.js
+++ b/processes/ripple_billing.js
@@ -16,14 +16,12 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+module.exports = function(codius) {
 
-var BridgesApplication = require('bridges-application');
-var codius             = require(__dirname+'/lib');
-
-new BridgesApplication({
-  directory: __dirname,
-  processes: {
-    inject: [codius]
+  if (codius.features.isEnabled('RIPPLE_BILLING')) {
+    if (!codius.config.get('RIPPLE_ADDRESS')) {
+      throw new Error('RIPPLE_ADDRESS must be set in environment to enable Ripple billing')
+    }
   }
-}).supervisor.start();
+}
 

--- a/processes/server.js
+++ b/processes/server.js
@@ -17,13 +17,8 @@
 */
 //==============================================================================
 
-var BridgesApplication = require('bridges-application');
-var codius             = require(__dirname+'/lib');
+module.exports = function(codius) {
 
-new BridgesApplication({
-  directory: __dirname,
-  processes: {
-    inject: [codius]
-  }
-}).supervisor.start();
+  new codius.Server().start();
+}
 


### PR DESCRIPTION
Logically separate all long-running processes with CodiusHost, including:
- express server
- bitcoin billing / monitor
- contract balance amortizer
- ripple billing / monitor

Each sub-process is fault isolated from the others, and each now has its own file under /processes.

To add new sub-processes to Codius Host create a new file under /processes
