### PR TITLE
Properly determine path of directory 'migrations'

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -17,9 +17,14 @@
 */
 //==============================================================================
 
+var path = require('path');
 var nconf = require('./config');
 
-var knex = require('knex').initialize(nconf.get('db'));
+var conf = nconf.get('db');
+
+conf.migrations = { directory: path.resolve(__dirname, '../migrations') };
+
+var knex = require('knex').initialize(conf);
 var bookshelf = require('bookshelf').initialize(knex);
 
 exports.knex = knex;


### PR DESCRIPTION
Codius-host is sometimes looking for migrations in wrong directory because it uses current working directory when it calculates the path.

For example, when I execute "/usr/bin/codius-host start" in directory /tmp, codius-host fails to start because there is no directory /tmp/migrations.

Please let me know if this is not the correct branch for such pull requests. Develop branch is quite behind the master branch.
