### PR TITLE
[FIX] Order of default config definitions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,10 +32,6 @@ nconf.defaults({
     "contractsFilesystemPath": nconf.get('CONTRACTS_STORAGE'),
     "disableNacl": true
   },
-  "ssl": {
-    "cert": nconf.get('SSL_CERT'),
-    "key": nconf.get('SSL_KEY')
-  },
   "compute_units_per_bitcoin": 45000000,
   "compute_units_per_drop": 0.0075,
   "milliseconds_per_compute_unit": 1000,
@@ -44,6 +40,11 @@ nconf.defaults({
   'SSL_KEY': path.join(__dirname, '/../server.key'),
   'CONTRACTS_STORAGE': 'contract_filesystem/'
 });
+
+nconf.set("ssl", {
+  "cert": nconf.get('SSL_CERT'),
+  "key": nconf.get('SSL_KEY')
+})
 
 if (nconf.get('NODE_ENV') === 'fig') {
   // nconf doesn't support multiple layers of defaults


### PR DESCRIPTION
`SSL_CERT` and `SSL_KEY` were being used before getting default values.
[Fixes #89535034]
