### PR TITLE
[FIX] Do not delete files of terminated apps

### DIFF
--- a/lib/compute_service.js
+++ b/lib/compute_service.js
@@ -110,10 +110,12 @@ ComputeService.prototype.startInstance = function(token, container_uri, type, va
       }
       var manifest = runner.getManifest(contractHash);
       var p = [];
-      _.each(manifest.files, function(file) {
-        p.push(deleteFile(file))
-      });
-      p.push(deleteFile(contractHash));
+
+      // TODO: Check if files are used in other running applications before deleting.
+      // _.each(manifest.files, function(file) {
+      //   p.push(deleteFile(file))
+      // });
+      // p.push(deleteFile(contractHash));
 
       Promise.all(p).then(function() {
         winston.debug(contractIdent, chalk.dim('+++'), 'Instance terminated');


### PR DESCRIPTION
TODO: File deletion needs to first check if file is used in other running instances
